### PR TITLE
Make DB initialization ~3x faster by caching norm.pdf calls.

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -20,6 +20,19 @@ def create(agent_conf):
                    *AgentType.query.all(),
                    *CurrencyType.query.all()]:
         db.session.delete(record)
+    # This approach should be better, but benchmarks
+    # show minimal differences, since the slow part
+    # is the call to seed_agents.seed()
+    #models = [
+        #AgentStateAttribute,
+        #AgentState,
+        #AgentTypeAttributeDetails,
+        #AgentTypeAttribute,
+        #AgentType,
+        #CurrencyType,
+    #]
+    #for model in models:
+        #db.session.query(model).delete()
     db.session.commit()
     seed_agents.seed(agent_conf)
 
@@ -38,6 +51,10 @@ if __name__ == "__main__":
             create(app.config["AGENT_CONFIG"])
             break
         except Exception as e:
+            # TODO: catch sqlalchemy.exc.DatabaseError: (mysql.connector.errors.DatabaseError)
+            #    2003 (HY000): Can't connect to MySQL server on 'simoc-db' (111)
+            # specifically instead of all errors.
+            #print('*** Error:', e)
             app.logger.info(e)
             if num_retries > 0:
                 num_retries -= 1


### PR DESCRIPTION
The attached PR adds caching to the `norm.pdf()` calls in `get_bell_curve` and `get_clipped_bell_curve`.

This function gets called about ~15k calls during DB initialization, but with only a dozen of different combinations of args, as showed by the cache info: `CacheInfo(hits=15604, misses=12, maxsize=128, currsize=12)`.

Adding caching directly on `get_bell_curve` and `get_clipped_bell_curve` using `functools.lru_cache` doesn't work because not all arguments are hashable.  I tried factoring out the `norm.pdf` call and adding `lru_cache()` to that, and while it works for the inputs, it ends up caching the output which is a mutable `numpy.ndarray`, and this causes issues since the same array gets shared by a lot of callers, that might end up editing affecting the other calls.

Eventually I manually implemented a cache that creates a brand new copy of the cached array before returning it.

I did some testing and this makes DB creation ~3x faster (from ~135s to ~40s), but doesn't seem to affect step calculation while running sims.  The sim results seem close, the small variations are likely due to rounding errors and the order in which the agents are processed (which seems random).  Similar small variations have been observed from run to run even before this optimization.

I found this bottleneck by using the `profile` and `pstats` module in the stdlib.  `py-spy` might also be useful for further profiling.  While investing bottlenecks I also found out that the queries in [create_db.py:create](https://github.com/overthesun/simoc/blob/master/create_db.py#L14) can be optimized but they are so fast (<1s) that the optimization doesn't make any difference, so I added a comment but haven't changed it.

The final breakdown to rebuild the db is:
* `40s` to seed agents
* `15s` spent making queries
* `15s` starting/stopping containers

[seed_agents.py:calculate_growth_coef](https://github.com/overthesun/simoc/blob/master/simoc_server/database/seed_data/seed_agents.py#L190) performs several queries (~2500 selects + ~180 create/insert/update, over a dozen of calls), and I suspect is where most of the 15s above are spent.

Another issue is that it's not possible to run `create_db.py` without deleting the DB first, and deleting the DB has two negative side-effects:
1. it deletes all the users too
2. it takes some extra time (the `15s` above)

Fixing that would solve both issues, making DB creation even faster.