### PR TITLE
Update deprecated setup-gcloud GitHub action.

### DIFF
--- a/.github/workflows/build-backend-prod.yml
+++ b/.github/workflows/build-backend-prod.yml
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           path: simoc-web
       - name: Set up gcloud CLI
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '290.0.1'
           service_account_key: ${{ secrets.GKE_SA_KEY }}
@@ -114,7 +114,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Set up gcloud CLI
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '290.0.1'
           service_account_key: ${{ secrets.GKE_SA_KEY }}


### PR DESCRIPTION
During the last deployment I noticed this warning:
```
Thank you for using setup-gcloud Action. GoogleCloudPlatform/github-actions/setup-gcloud
has been deprecated, please switch to google-github-actions/setup-gcloud.
```

This PR updates the deprecated GitHub action to the updated version.