### PR TITLE
Sam backend

### DIFF
--- a/agent_desc.json
+++ b/agent_desc.json
@@ -6062,7 +6062,7 @@
                     },
                     {
                         "type": "volume",
-                        "value": "367",
+                        "value": "494",
                         "unit": "m^3"
                     }
                 ]


### PR DESCRIPTION
Update agent_desc.json file to include agents used in the SAM-preset configuration (https://github.com/overthesun/simoc-web/pull/77):

- 'crew_habitat_sam': copied from 'crew_habitat_small' with volume changed to 272 m^3.
(1200 ft2 * 8' ceiling = 9600 ft^3 = 271.8417 m^3)
source: Kai's message on WhatsApp

- 'greenhouse_sam': copied from 'greenhouse_small' with volume changed to 494 m^3. 
(10974 + 100 + 4480 + 1897 = 17451 ft^3 = 494.15729 m^3)
source: https://samb2.space/2021/06/25/sam-construction-resealing-the-lung/ 

*NOTE*
I used the ACE (running on beta.simoc.space) to generate the new agent_desc, so there are some miscellaneous formatting changes in addition to the above. This seems like a necessary update, and an appropriate occasion to do it.