### PR TITLE
pull models and skybox from server on boot

### DIFF
--- a/.github/workflows/build-backend-prod.yml
+++ b/.github/workflows/build-backend-prod.yml
@@ -67,6 +67,18 @@ jobs:
           mkdir simdata
           cd simdata
           wget -r -nH --cut-dirs=2 --no-parent --accept="*.json" -erobots=off -q --show-progress https://simoc.space/download/simdata/
+      - name: Download models
+        working-directory: simoc-web/src/assets
+        run: |
+          mkdir models
+          cd models
+          wget -r -nH --cut-dirs=2 --no-parent --accept="*.glb" -erobots=off -q --show-progress https://simoc.space/download/models/
+      - name: Download skybox
+        working-directory: simoc-web/src/assets
+        run: |
+          mkdir skybox
+          cd skybox
+          wget -r -nH --cut-dirs=2 --no-parent --accept="*.jpg" -erobots=off -q --show-progress https://simoc.space/download/skybox/
       - name: npm install and build
         working-directory: simoc-web
         run: |

--- a/.github/workflows/build-backend-staging.yml
+++ b/.github/workflows/build-backend-staging.yml
@@ -56,6 +56,18 @@ jobs:
           mkdir simdata
           cd simdata
           wget -r -nH --cut-dirs=2 --no-parent --accept="*.json" -erobots=off -q --show-progress https://simoc.space/download/simdata/
+      - name: Download models
+        working-directory: simoc-web/src/assets
+        run: |
+          mkdir models
+          cd models
+          wget -r -nH --cut-dirs=2 --no-parent --accept="*.glb" -erobots=off -q --show-progress https://simoc.space/download/models/
+      - name: Download skybox
+        working-directory: simoc-web/src/assets
+        run: |
+          mkdir skybox
+          cd skybox
+          wget -r -nH --cut-dirs=2 --no-parent --accept="*.jpg" -erobots=off -q --show-progress https://simoc.space/download/skybox/
       - name: npm install and build
         working-directory: simoc-web
         run: |


### PR DESCRIPTION
This update accompanies the ThreeJS update on simoc-web. It downloads the 3d models and skybox images when the container starts, just like it does with simdata.