### PR TITLE
Stop using DockerHub for local installations.

### DIFF
--- a/docker-compose.mysql.yml.jinja
+++ b/docker-compose.mysql.yml.jinja
@@ -63,7 +63,11 @@ services:
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
   celery-worker:
+    {% if use_dockerhub %}
     image: {{ docker_repo }}/simoc_celery:{{ version }}
+    {% else %}
+    image: simoc_celery:{{ version }}
+    {% endif %}
     restart: always
     networks:
       - simoc-net
@@ -87,7 +91,11 @@ services:
       - simoc-db
       - redis
   flask-app:
+    {% if use_dockerhub %}
     image: {{ docker_repo }}/simoc_flask:{{ version }}
+    {% else %}
+    image: simoc_flask:{{ version }}
+    {% endif %}
     restart: always
     ports:
       - 8080

--- a/simoc.py
+++ b/simoc.py
@@ -113,6 +113,13 @@ def make_cert():
                 '-subj', f"/C=US/ST=Texas/L=Austin/O=SIMOC/CN={domain}"])
 
 @cmd
+def build_images():
+    """Build the flask and celery images locally."""
+    return (run(['docker', 'build', '-t', 'simoc_flask', '.']) and
+            run(['docker', 'build', '-f', 'Dockerfile-celery-worker',
+                 '-t', 'simoc_celery', '.']))
+
+@cmd
 def start_services():
     """Starts the services."""
     return docker_compose('up', '-d',
@@ -204,7 +211,7 @@ def flask_logs():
 @cmd
 def setup():
     """Run a complete setup of SIMOC."""
-    return (generate_scripts() and make_cert() and
+    return (generate_scripts() and make_cert() and build_images() and
             start_services() and init_db() and ps())
 
 @cmd
@@ -218,6 +225,12 @@ def reset():
     """Remove everything, then run a full setup."""
     return teardown() and setup()
 
+
+# debugging/testing
+@cmd
+def shell(container):
+    """Run an interactive shell in the specified container."""
+    return docker_compose('exec', container, '/bin/bash')
 
 # others
 @cmd

--- a/simoc_docker.env
+++ b/simoc_docker.env
@@ -1,3 +1,4 @@
+export USE_DOCKERHUB=0
 export DOCKER_REPO='imilov'
 export SERVER_NAME='localhost'
 export HTTP_PORT=8000

--- a/simoc_docker_beta.env
+++ b/simoc_docker_beta.env
@@ -1,3 +1,4 @@
+export USE_DOCKERHUB=1
 export DOCKER_REPO='imilov'
 export SERVER_NAME='beta.simoc.space'
 export HTTP_PORT=80


### PR DESCRIPTION
With this PR, local installation build the `simoc_flask` and `simoc_celery` images locally instead of downloading them from DockerHub.  This allows us to have local installations for multiple users without running in the limitations of DockerHub (one collaborator per each private repo).

Beta will keep relying on DockerHub.