### PR TITLE
Update Docker images to Ubuntu 21.10, update pip and gevent.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:21.10
 
 MAINTAINER Iurii Milovanov "duruku@gmail.com"
 
@@ -6,7 +6,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3-pip \
     python3-setuptools \
-    curl
+    curl && \
+    python3 -m pip install --upgrade pip
 
 COPY ./requirements.txt /simoc/requirements.txt
 RUN python3 -m pip install -r /simoc/requirements.txt

--- a/Dockerfile-celery-worker
+++ b/Dockerfile-celery-worker
@@ -1,11 +1,13 @@
-FROM ubuntu:18.04
+FROM ubuntu:21.10
 
 MAINTAINER Iurii Milovanov "duruku@gmail.com"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3-pip \
-    python3-setuptools
+    python3-setuptools \
+    curl && \
+    python3 -m pip install --upgrade pip
 
 COPY ./requirements.txt /simoc/requirements.txt
 RUN python3 -m pip install -r /simoc/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flask
 flask-login
 flask_socketio
 flask-sqlalchemy
-gevent==1.4.0
+gevent
 gunicorn
 jinja2
 mesa


### PR DESCRIPTION
This PR updates the base Ubuntu image from 18.04 to 21.10.

After the update `gevent` failed to build.  I tried to solve the issue by updating `pip` but that didn't work (I left it anyway because it's better to run an updated version anyway).

Apparently the problem was that we had a specific version of `gevent` in the requirements (`1.4.0`) that is not compatible with newer versions of Python (21.10 has Python 3.9).  I tried removing the version and everything seems to work fine locally.  I'll test on beta before merging.