### PR TITLE
remove call to save game

### DIFF
--- a/simoc_server/game_runner.py
+++ b/simoc_server/game_runner.py
@@ -466,7 +466,7 @@ class GameRunnerManager(object):
         """
         old_game = self.get_game_runner(user)
         if old_game is not None:
-            app.logger.info('Aborting current game without saving.')
+            app.logger.info(f'Overriding game runner for {user}')
             # self.save_game(user, allow_repeat_save=False)
         self.game_runners[user.id] = game_runner
 


### PR DESCRIPTION
The database is no longer configured to hold save data, and it looks like the `save_game` method was [phased out](https://github.com/overthesun/simoc/commit/e70058ac26a77e732def9ab90370671f47eee293) by Iurii in April 2020 'until model persistence is fixed.' It was still being called by the `GameRunnerManager` if a user has a current simulation and tries to load another one. I've replaced the call to `save_game` with a log message that says game was aborted without saving.

I notice that, before, if I ran a simulation locally and then hit 'back' and tried again with a new configuration, it would fail. I instead had to reload `localhost:8080` to start a new simulation. Now it works fine. I guess it was stalling on that `save_game` call. 