### PR TITLE
Update scikit-learn and revert a workaround.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pytest
 pytimeparse
 quantities
 redis
-scikit-learn>=0.23,!=0.24.0,!=0.24.1
+scikit-learn
 scipy
 setuptools
 sqlalchemy


### PR DESCRIPTION
This fixes #118 and the problem seems now solved.
I tried updating `scikit-learn` to see if it fixed issue #189, but it didn't.

Also note that `scikit-learn` got bumped to 1.1.1, but according to https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_0_0.html : 
> This release does not include any breaking changes apart from the usual two-release deprecation cycle. For the future, we do our best to keep this pattern.