### PR TITLE
Remove double timestamp from Docker logs.

### DIFF
--- a/simoc.py
+++ b/simoc.py
@@ -195,17 +195,17 @@ def ps(*args):
 @cmd
 def logs(*args):
     """Show all logs."""
-    return docker_compose('logs', '-t', '-f', *args)
+    return docker_compose('logs', '-f', *args)
 
 @cmd
-def celery_logs():
+def celery_logs(*args):
     """Show the celery logs."""
-    return docker_compose('logs', '-t', '-f', 'celery-worker')
+    return docker_compose('logs', '-f', 'celery-worker', *args)
 
 @cmd
-def flask_logs():
+def flask_logs(*args):
     """Show the flask logs."""
-    return docker_compose('logs', '-t', '-f', 'flask-app')
+    return docker_compose('logs', '-f', 'flask-app', *args)
 
 
 # install/uninstall


### PR DESCRIPTION
This PR removes double timestamps from Docker logs.

Before:
```sh
flask-app_1      | 2022-06-04T23:06:17.589551416Z [2022-06-04 23:06:17 +0000] [8] [DEBUG] Closing connection. 
flask-app_1      | 2022-06-04T23:07:17.792213334Z [2022-06-04 23:07:17 +0000] [8] [DEBUG] GET /ping
flask-app_1      | 2022-06-04T23:07:17.793404314Z [2022-06-04 23:07:17 +0000] [8] [DEBUG] Closing connection. 
flask-app_1      | 2022-06-04T23:08:17.982315721Z [2022-06-04 23:08:17 +0000] [8] [DEBUG] GET /ping
```

After:
```sh
flask-app_1      | [2022-06-04 23:06:17 +0000] [8] [DEBUG] Closing connection. 
flask-app_1      | [2022-06-04 23:07:17 +0000] [8] [DEBUG] GET /ping
flask-app_1      | [2022-06-04 23:07:17 +0000] [8] [DEBUG] Closing connection. 
flask-app_1      | [2022-06-04 23:08:17 +0000] [8] [DEBUG] GET /ping
```

Most log lines already seem to have a timestamp.  The Docker timestamp can also be enabled again by doing:
```
python3 simoc.py --with-dev-backend logs -- -t
```