### PR TITLE
Pin `mysql-connector-python` version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gunicorn
 jinja2
 mesa
 msgpack-python
-mysql-connector-python
+mysql-connector-python==8.0.29
 nose
 numpy
 pytest


### PR DESCRIPTION
Version 8.0.30 of [`mysql-connector-python`](https://pypi.org/project/mysql-connector-python/) might be causing some issues that might not affect 8.0.29.

In the log the following error appears:
```
[2022-08-01 17:07:28,939: ERROR/ForkPoolWorker-2] celery_worker.tasks.new_game[976496b0-fda9-4fe1-b7fd-38194f74e332]:
  Exception in task.get_user(username='eziom') ((mysql.connector.errors.ProgrammingError)
  Character set '255' unsupported (Background on this error at: https://sqlalche.me/e/14/f405)): rolling back
[2022-08-01 17:07:28,939: WARNING/ForkPoolWorker-2] celery_worker.tasks.new_game[976496b0-fda9-4fe1-b7fd-38194f74e332]:
  User 'eziom' NOT found (num_retries=30 left): user=[]
[2022-08-01 17:07:29,958: INFO/ForkPoolWorker-2] celery_worker.tasks.new_game[976496b0-fda9-4fe1-b7fd-38194f74e332]:
  User found (num_retries=29 left): <User id=32 username=eziom>
```

The following thread suggest that it might be caused by the latest version of `mysql-connector-python` -- this PR pins the previous version to see if it solves the issue:

https://www.reddit.com/r/mariadb/comments/wa96kh/mysqlconnectorerrorsprogrammingerror_character/