### PR TITLE
Fix Celery checkhealth command to adhere to Celery 5.0+ syntax

### DIFF
--- a/ping_worker.sh
+++ b/ping_worker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-celery inspect ping -b "redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/" -d worker@$HOSTNAME
+celery -b "redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/" inspect ping -d worker@$HOSTNAME


### PR DESCRIPTION
This will fix the issues with the probe failing and clean up the container health and logs from false positives in GKE.