### PR TITLE
increase memory limit for k8s celery container

### DIFF
--- a/k8s/deployments/simoc_celery_cluster.yaml.jinja
+++ b/k8s/deployments/simoc_celery_cluster.yaml.jinja
@@ -81,5 +81,5 @@ spec:
               memory: "300M"
               cpu: .5
             limits:
-              memory: "500M"
+              memory: "550M"
               cpu: .7


### PR DESCRIPTION
This will increase the celery memory limit to 550MB to hopefully fix the issue seen in ngs.simoc.space regarding the OOM issues seen in the Google cloud console. 

It may need to be increased further if issues are still seen with certain data sets as we increase our capabilities of SIMOC in B2.