### PR TITLE
Set celery memory limit to 600M.

### DIFF
--- a/k8s/deployments/simoc_celery_cluster.yaml.jinja
+++ b/k8s/deployments/simoc_celery_cluster.yaml.jinja
@@ -81,5 +81,5 @@ spec:
               memory: "300M"
               cpu: .5
             limits:
-              memory: "550M"
+              memory: "600M"
               cpu: .7


### PR DESCRIPTION
Follow up of:
* #202 
* #200 

600M seems to be good enough to run the presets with 365 days, but might still result in 500 errors when heavier sims are run.