### PR TITLE
Improve `docker` setup in `simoc.py`.

### DIFF
--- a/simoc.py
+++ b/simoc.py
@@ -97,20 +97,27 @@ def print_env():
 
 # initial setup
 def install_docker():
-    """Install docker and docker-compose and start the docker daemon."""
+    """Install docker and docker-compose."""
+    return install_docker_linux()
+
+def install_docker_linux():
+    # this function is duplicated in overthesun/simoc-web/simoc-web.py,
+    # changes to this function should be ported there too
     if docker_available():
         return True
+    # `apt` already creates a `docker` group, but we need to manually
+    # add the current user to it and ask the user to log out/log in
+    # for the change to take place and for `docker` to work without `sudo`
     print('Installing docker and docker-compose:')
-    if not run(['sudo', 'apt', 'install', 'docker', 'docker-compose']):
+    user = os.getenv('USER')
+    if not (run(['sudo', 'apt', 'install', '-y', 'docker', 'docker-compose']) and
+            run(['sudo', 'usermod', '-aG', 'docker', user])):
         return False
-    ATTEMPTS = 10
-    for attempt in range(ATTEMPTS):
-        time.sleep((attempt+1)*5)
-        print(f'Starting docker (attempt {attempt+1}/{ATTEMPTS}):')
-        if run(['sudo', 'systemctl', 'start', 'docker']):
-            return True
-    else:
-        return False
+    print('Please log out and log in again (or restart the machine) '
+          'to complete the Docker installation.')
+    print('After logging back in, you can resume the installation of SIMOC.')
+    print()
+    return False
 
 def install_jinja():
     """Install Jinja2."""
@@ -119,7 +126,7 @@ def install_jinja():
         return True  # Jinja already installed
     except ImportError:
         print('Installing Jinja2:')
-        return run(['sudo', 'apt', 'install', 'python3-jinja2'])
+        return run(['sudo', 'apt', 'install', '-y', 'python3-jinja2'])
 
 @cmd
 def install_deps():


### PR DESCRIPTION
This PR is a follow-up of #204 and improves `docker` setup in `simoc.py`:
* it installs `docker` and `docker-compose` with `apt`
* it adds the current user to the `docker` group created by `apt`
* it asks the user to log out/log in or restart the machine for the changes to take place

After the user restarted, they can run the setup command again and `docker` will work fine.

The PR also includes two slightly unrelated refactorings:
1. it now uses the `--yes` option of `apt`, so that it doesn't prompt the user
2. it created a separated `install_docker_linux` function to make it easier to add a different `install_docker_macos` function later

It also removes a somewhat ugly workaround that was used to ensure that the docker daemon was working, and is now no longer needed since we ask the user to restart.