### PR TITLE
Fix incorrect rst markup and tweak conf.py.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,12 +64,12 @@ release = '1.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/developer/deployment.rst
+++ b/docs/developer/deployment.rst
@@ -39,13 +39,13 @@ In order to deploy:
 
 The branch you specify in step 3 can be:
 
-* a named branch (such as `master`)
+* a named branch (such as ``master``)
 * a pull request, by specifying :samp:`refs/pull/{NUM}/head`
   (where *NUM* is the PR number)
 * a specific commit ID
 
-`master` is considered the stable branch for both the `simoc` and
-`simoc-web` repository, and generally only `master` should be
+``master`` is considered the stable branch for both the ``simoc`` and
+``simoc-web`` repository, and generally only ``master`` should be
 deployed on NGS.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. SIMOC Developer's Guide documentation master file, created by
    sphinx-quickstart on Sat Aug 28 22:34:16 2021.
    You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+   contain the root toctree directive.
 
 
 SIMOC Advanced User's Guide


### PR DESCRIPTION
This PR does two things:
* fixes invalid use of the default role in the rst docs
* sets the default docs language and ignores the `venv` in `conf.py`

This gets rid of a few warnings generated while building the docs.