### PR TITLE
Bump Traefik version

### DIFF
--- a/k8s/ingresses/traefik_values.yaml.jinja
+++ b/k8s/ingresses/traefik_values.yaml.jinja
@@ -1,6 +1,6 @@
 image:
   name: traefik
-  tag: 2.2.1
+  tag: 2.3.7
 
 additionalArguments:
   - "--accesslog"


### PR DESCRIPTION
This is going to bump traefik version up to 2.3.7 before we proceed to higher version to check for potential breaking changes in GKE.

Further discussion available in issue #250 