### PR TITLE
fix infinite loop

### DIFF
--- a/simoc_server/views.py
+++ b/simoc_server/views.py
@@ -115,7 +115,7 @@ def get_steps_handler(message):
     user_id = get_standard_user_obj().id
     old_game_id = redis_conn.get(f'sid_mapping:{request.sid}')
     if old_game_id:
-        redis_conn.set('stop_task:{}'.format(old_game_id), 1)
+        redis_conn.set(f'stop_task:{old_game_id}', 1)
     socketio.start_background_task(get_steps_background, message['data'], user_id, request.sid)
 
 
@@ -462,7 +462,7 @@ def get_last_game_id():
 
 
 def kill_game_by_id(game_id):
-    redis_conn.set('stop_task:{}'.format(game_id), '1')
+    redis_conn.set(f'stop_task:{game_id}', 1)
     task_id = redis_conn.get('task_mapping:{}'.format(game_id))
     task_id = task_id.decode("utf-8") if task_id else task_id
     app.logger.info(f"kill_game_by_id({game_id=:X}): revoke {task_id}")


### PR DESCRIPTION
This addresses Issue #300 .

The immediate cause was line 83. Fixing that (and rearranging some for clarity) activates the timeout sequence.

Really though it should stop earlier with the redis `stop_task` flag. This and `sid_mapping` had some inconsistencies, which I fixed. The behavior now is:
- When a user clicks 'back' from the dashboard on the frontend, the backend runs a 'user_cleanup'. This cancels the sim and (now) sets the 'stop_task' flag to stop the step-retrieval loop.
- When a user starts a new sim, as a backup, it checks for an existing sim under the same socket-io id, and if so, cancels it.