### PR TITLE
Update gcloud version

### DIFF
--- a/.github/workflows/build-backend-ngs.yml
+++ b/.github/workflows/build-backend-ngs.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Python Environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9'
       - name: Export gcloud related env variable
         run: export CLOUDSDK_PYTHON="/usr/bin/python3"
       - name: Set up gcloud CLI
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Python Environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9'
       - name: Export gcloud related env variable
         run: export CLOUDSDK_PYTHON="/usr/bin/python3"
       - name: Set up gcloud CLI


### PR DESCRIPTION
This should fix the following error seen in https://github.com/overthesun/simoc/actions/runs/4370383019:
```
google-github-actions/setup-gcloud failed with: failed to execute command `gcloud --quiet config set project ***`: ERROR: gcloud failed to load: module 'collections' has no attribute 'MutableMapping'
    gcloud_main = _import_gcloud_main()
    import googlecloudsdk.gcloud_main
    from googlecloudsdk.api_lib.iamcredentials import util as iamcred_util
    from googlecloudsdk.api_lib.util import exceptions
    from googlecloudsdk.core.resource import resource_printer
    from googlecloudsdk.core.resource import config_printer
    from googlecloudsdk.core.resource import resource_printer_base
    from googlecloudsdk.core.resource import resource_projector
    from google.protobuf import json_format as protobuf_encoding
    from google.protobuf import symbol_database
    from google.protobuf import message_factory
    from google.protobuf import reflection
    from google.protobuf.internal import python_message as message_impl
    from google.protobuf.internal import containers
    MutableMapping = collections.MutableMapping

This usually indicates corruption in your gcloud installation or problems with your Python interpreter.

Please verify that the following is the path to a working Python 2.7 or 3.5+ executable:
    /usr/bin/python

If it is not, please set the CLOUDSDK_PYTHON environment variable to point to a working Python 2.7 or 3.5+ executable.

If you are still experiencing problems, please reinstall the Cloud SDK using the instructions here:
    https://cloud.google.com/sdk/
```