### PR TITLE
Expect the simdata fname to already contain `.gz`

### DIFF
--- a/simoc_server/front_end_routes.py
+++ b/simoc_server/front_end_routes.py
@@ -28,8 +28,8 @@ from agent_model.agents.custom_funcs import hourly_par_fraction, monthly_par
 def serve_simdata(filename):
     """Serve static gzipped simdata files."""
     simdata_dir = pathlib.Path(__file__).resolve().parent / "dist" / "simdata"
-    fname_gz = filename + '.gz'
-    simdata_file = safe_join(simdata_dir, fname_gz)  # prevent path traversal
+    simdata_file = safe_join(simdata_dir, filename)  # prevent path traversal
+    app.logger.info(f'Serving preset simdata file: {simdata_file}')
     try:
         with open(simdata_file, 'rb') as f:
             data = f.read()


### PR DESCRIPTION
This PR goes with the following frontend PR:
* https://github.com/overthesun/simoc-web/pull/395

Currently the backend expects a preset simdata filename ending with `*.json`, and then adds the `.gz` extension before retrieving the local file.  This PR changes the backend to expect a filename ending with `*.json.gz`, and the PR linked above ensures that the `.gz` is added in the frontend.

This solves an issue seen on local build, where the frontend was requesting `*.json` files but vite was serving them directly without going through the backend (because of `vite.config.js`), so the `.gz` extension was never added and the preset was only loaded if the `*.json` files still happened to be in the `simdata` dir.