### PR TITLE
Print the branch names in dev builds

### DIFF
--- a/.github/workflows/build-backend-beta.yml
+++ b/.github/workflows/build-backend-beta.yml
@@ -32,7 +32,6 @@ env:
   VITE_FE_BRANCH: ${{ github.event.inputs.fe_branch }}
   VITE_BE_BRANCH: ${{ github.event.inputs.be_branch }}
 
-
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This goes with the following FE PR and ensures that the branch names are set while deploying from GitHub:
* https://github.com/overthesun/simoc-web/pull/403