### PR TITLE
Bump flask to 2.3.2 + werkzeug to 2.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 celery==5.2.7
-flask==2.2.2
+flask==2.3.2
 flask-login==0.6.2
 flask_socketio==5.3.2
 flask-sqlalchemy==2.5.1


### PR DESCRIPTION
This PR combines:
* #351  
* #358 

Flask requires an updated version of werkzeug, in order to work.