### PR TITLE
Pass the number of celery workers from the workflow

### DIFF
--- a/.github/workflows/build-backend-beta.yml
+++ b/.github/workflows/build-backend-beta.yml
@@ -154,6 +154,6 @@ jobs:
           copy_stack_file: true
           deploy_path: /home/beta.simoc/simoc
           stack_file_name: docker-compose.mysql.yml
-          args: "up -d --scale celery-worker=${{ env.celery_workers }} flask-app=${{ env.flask_workers }}"
+          args: "up -d --scale celery-worker=${{ env.celery_workers }} --scale flask-app=${{ env.flask_workers }}"
           docker_prune: false
           pull_images_first: true


### PR DESCRIPTION
This should fix the number of celery containers on beta by passing the number of workers from the workflow.