### PR TITLE
Set Celery/Flask workers in the dockerfile

### DIFF
--- a/docker-compose.mysql.yml.jinja
+++ b/docker-compose.mysql.yml.jinja
@@ -76,6 +76,7 @@ services:
     image: simoc_celery:{{ version }}
     {% endif %}
     restart: always
+    scale: ${CELERY_WORKERS}
     networks:
       - simoc-net
     healthcheck:
@@ -104,6 +105,7 @@ services:
     image: simoc_flask:{{ version }}
     {% endif %}
     restart: always
+    scale: ${FLASK_WORKERS}
     ports:
       - 8080
     networks:

--- a/simoc.py
+++ b/simoc.py
@@ -42,9 +42,6 @@ try:
 except FileNotFoundError:
     sys.exit(f"Can't find env file: {ENV_FILE!r}")
 
-FLASK_WORKERS = ENVVARS['FLASK_WORKERS']
-CELERY_WORKERS = ENVVARS['CELERY_WORKERS']
-
 # update environ with the new envvars
 os.environ.update(ENVVARS)
 
@@ -171,10 +168,7 @@ def build_images():
 @cmd
 def start_services():
     """Starts the services."""
-    return docker_compose('up', '-d',
-                          '--force-recreate',
-                          '--scale', f'celery-worker={CELERY_WORKERS}',
-                          '--scale', f'flask-app={FLASK_WORKERS}')
+    return docker_compose('up', '-d', '--force-recreate')
 
 # DB
 @cmd


### PR DESCRIPTION
This PR is an alternative approach to #365, that instead of passing the number of Celery/Flask workers as an arg to `docker-compose up --scale`, it specifies it in the dockerfile.  This should make things simpler since the number of workers no longer has to be passed around, both in `simoc.py` and in the GitHub action.