### PR TITLE
Switch the server name from beta to ngs to fix SSL cert issues

### DIFF
--- a/simoc_docker_beta.env
+++ b/simoc_docker_beta.env
@@ -1,6 +1,6 @@
 export USE_DOCKERHUB=1
 export DOCKER_REPO='imilov'
-export SERVER_NAME='beta.simoc.space'
+export SERVER_NAME='ngs.simoc.space'
 export HTTP_PORT=80
 export HTTPS_PORT=443
 export USE_SSL=1


### PR DESCRIPTION
Currently both `ngs.simoc.space` and `beta.simoc.space` point to the same server.  The deployment is done assuming the server is accessible through `beta.simoc.space` only, and it creates a letsencrypt cert for it.  While accessing it through `ngs.simoc.space` there is no SSL cert and the user sees a warning.  This PR changes the `SERVER_NAME` var from `beta.simoc.space` to `ngs.simoc.space`, so that the generated cert will work for `ngs.simoc.space`.  It will start failing for `beta.simoc.space`, but we can handle the warning better than our users can.

This is just a temporary workaround while we get around installing separate certs for both.