### PR TITLE
Add custom `--env-file` support to simoc.py

### DIFF
--- a/simoc.py
+++ b/simoc.py
@@ -36,13 +36,14 @@ def parse_env(fname):
                 print(f'Unrecognized line in {fname}: {line!r}')
     return env
 
-try:
-    ENVVARS = parse_env(ENV_FILE)
-except FileNotFoundError:
-    sys.exit(f"Can't find env file: {ENV_FILE!r}")
-
-# update environ with the new envvars
-os.environ.update(ENVVARS)
+def update_env(env_file):
+    try:
+        envvars = parse_env(env_file)
+    except FileNotFoundError:
+        sys.exit(f"Can't find env file: {env_file!r}")
+    # update environ with the new envvars
+    os.environ.update(envvars)
+    return envvars
 
 COMMANDS = {}
 
@@ -389,6 +390,10 @@ Use the `--with-dev-backend` flag to run the dev backend container.
         help='the docker-compose yml file (default: %(default)r)'
     )
     parser.add_argument(
+        '--env-file', metavar='FILE', default=ENV_FILE,
+        help='the env file (default: %(default)r)'
+    )
+    parser.add_argument(
         '--with-dev-backend', action='store_true',
         help='use the dev backend flask container'
     )
@@ -408,6 +413,11 @@ Use the `--with-dev-backend` flag to run the dev backend container.
     if args.docker_file:
         COMPOSE_FILE = args.docker_file
         DOCKER_COMPOSE_CMD = ['docker-compose', '-f', COMPOSE_FILE]
+
+    if args.env_file:
+        ENV_FILE = args.env_file
+    ENVVARS = update_env(ENV_FILE)
+
     if args.dev_backend_yml and not args.with_dev_backend:
         parser.error("Can't specify the dev backend yml without --with-dev-backend")
 


### PR DESCRIPTION
This PR adds a new `--env-file` arg to `simoc.py` to specify a custom `env` file.  This has been extracted from #360 since it's a generic feature that it's also needed elsewhere.