### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
 __pycache__
 *.diff
+.DS_Store
 
 # Sphinx documentation
 docs/_build/
 
+# frontend dir
+simoc_server/dist/
+ 
+# SSL certificates
 certs/
+certbot/
 
 data_analysis/
 
-.DS_Store
 docker-compose.mysql.yml
 simoc_nginx.conf


### PR DESCRIPTION
This PR adds `certbot/` and `simoc_server/dist/` to `.gitignore`.  The former is generated and used by the Certbot container, whereas the latter hosts the frontend generated and copied over by the frontend container.