### PR TITLE
Fix websocket issues by pinning working versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,16 @@
 celery==5.3.1
 flask==2.3.3
 flask-login==0.6.2
-flask_socketio==5.3.6
+# Something broke upgrading flask_socketio to 5.3.5
+# so we are temporarily pinning it back to 5.3.2,
+# however that's not enough because that will still
+# install more recent versions of python-socketio/engineio
+# which contain the bug, so those are now pinned too.
+# Once the issue with python-socketio/engineio is solved,
+# flask_socketio can be upgraded again and the other two removed.
+flask_socketio==5.3.2
+python-socketio==5.8.0
+python-engineio==4.6.1
 flask-sqlalchemy==2.5.1
 gevent==22.10.2
 gunicorn==20.1.0


### PR DESCRIPTION
TL;DR: after upgrading to `flask_socketio` from 5.3.2 to 5.3.5 in #404, something broke with websockets and we were unable to send payload bigger than ~500kB.  Reverting to 5.3.2 didn't work, because `flask_socketio` depends on `python-socketio` and `python-engineio`, which actually are the cause of the issue, and even with `flask_socketio` 5.3.2 the latest version of those was pulling.

This PR temporarily reverts `flask_socketio` to 5.3.2 and also pins `python-socketio` and `python-engineio` to the last known working version.

Next steps:

- [ ] figure out the exact version of `python-socketio`/`python-engineio` that breaks things
- [ ] upgrade to that version
- [ ] check if there is an issue upstream about it, and if not report it
- [ ] once the issue upstream is fixed remove the pins for `python-socketio`/`python-engineio` and upgrade `flask_socketio` 