### PR TITLE
Update socketio dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask-login==0.6.2
 # flask_socketio can be upgraded again and the other two removed.
 flask_socketio==5.3.6
 python-socketio==5.8.0
-python-engineio==4.6.1
+python-engineio==4.7.0
 flask-sqlalchemy==2.5.1
 gevent==22.10.2
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ flask-login==0.6.2
 # which contain the bug, so those are now pinned too.
 # Once the issue with python-socketio/engineio is solved,
 # flask_socketio can be upgraded again and the other two removed.
-flask_socketio==5.3.2
+flask_socketio==5.3.6
 python-socketio==5.8.0
 python-engineio==4.6.1
 flask-sqlalchemy==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask-login==0.6.2
 # Once the issue with python-socketio/engineio is solved,
 # flask_socketio can be upgraded again and the other two removed.
 flask_socketio==5.3.6
-python-socketio==5.9.0
+python-socketio==5.10.0
 python-engineio==4.8.0
 flask-sqlalchemy==2.5.1
 gevent==22.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask-login==0.6.2
 # flask_socketio can be upgraded again and the other two removed.
 flask_socketio==5.3.6
 python-socketio==5.9.0
-python-engineio==4.7.0
+python-engineio==4.7.1
 flask-sqlalchemy==2.5.1
 gevent==22.10.2
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask-login==0.6.2
 # flask_socketio can be upgraded again and the other two removed.
 flask_socketio==5.3.6
 python-socketio==5.9.0
-python-engineio==4.7.1
+python-engineio==4.8.0
 flask-sqlalchemy==2.5.1
 gevent==22.10.2
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask-login==0.6.2
 # flask_socketio can be upgraded again and the other two removed.
 flask_socketio==5.3.6
 python-socketio==5.10.0
-python-engineio==4.8.0
+python-engineio==4.7.0
 flask-sqlalchemy==2.5.1
 gevent==22.10.2
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask-login==0.6.2
 # Once the issue with python-socketio/engineio is solved,
 # flask_socketio can be upgraded again and the other two removed.
 flask_socketio==5.3.6
-python-socketio==5.10.0
+python-socketio==5.9.0
 python-engineio==4.7.0
 flask-sqlalchemy==2.5.1
 gevent==22.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask-login==0.6.2
 # Once the issue with python-socketio/engineio is solved,
 # flask_socketio can be upgraded again and the other two removed.
 flask_socketio==5.3.6
-python-socketio==5.8.0
+python-socketio==5.9.0
 python-engineio==4.7.0
 flask-sqlalchemy==2.5.1
 gevent==22.10.2


### PR DESCRIPTION
This is a follow-up of:
* #437

In this PR I'll try to bump the versions of the 3 socketio-related packages to pinpoint where the issues were introduced.  The dependencies are:
* `flask_socketio`
* `python-socketio`
* `python-engineio`