### PR TITLE
Add `gevent-websocket` as a dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ flask_socketio==5.3.6
 python-socketio==5.9.0
 python-engineio==4.7.0
 flask-sqlalchemy==2.5.1
+gevent-websocket==0.10.1
 gevent==22.10.2
 gunicorn==20.1.0
 jinja2==3.1.2

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-gunicorn -w 1 -k gevent -b 0.0.0.0:8080 --log-level debug --timeout 120 simoc_server:app
+gunicorn -w 1 -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker -b 0.0.0.0:8080 --log-level debug --timeout 120 simoc_server:app


### PR DESCRIPTION
Without an additional websocket lib, our socketio connection relies on long polling.  Starting from `python-engineio` 4.7.1, `simple-websocket` has been added, but it seems to have issues with `gevent`/`gunicorn`/`flask`.  `gevent-websocket` seems to work fine.