### PR TITLE
Update default deploy host target while beta is offline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
         options:
           - beta
           - ngs
-        default: beta
+        default: ngs
       
 jobs:
   build-frontend:


### PR DESCRIPTION
`beta` is currently offline, so deploying to `beta` will not work.
This PR (temporarily) changes the default host to `ngs`.