### PR TITLE
Avoid running Docker as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM ubuntu:24.04
 
-LABEL maintainer="wolf@overthesun.com"
+LABEL maintainer="ezio.melotti@gmail.com"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3-venv \
     python3-dev \
     build-essential \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create and activate a virtual environment
 ENV VIRTUAL_ENV=/opt/venv
@@ -20,6 +21,11 @@ COPY ./requirements.txt /simoc/requirements.txt
 RUN pip install -r /simoc/requirements.txt
 
 COPY . /simoc
+
+# Create a non-root user and set permissions
+RUN groupadd -r simoc && \
+    useradd --no-log-init -r -g simoc -s /bin/bash simoc && \
+    chown -R simoc:simoc /simoc /opt/venv
 
 ARG DB_TYPE
 ARG DB_HOST
@@ -48,6 +54,7 @@ ENV LANG=C.UTF-8
 
 EXPOSE 8080
 
+USER simoc
 WORKDIR /simoc
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile-celery-worker
+++ b/Dockerfile-celery-worker
@@ -7,7 +7,8 @@ RUN apt-get update && \
     python3-venv \
     python3-dev \
     build-essential \
-    curl
+    curl && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create and activate a virtual environment
 ENV VIRTUAL_ENV=/opt/venv
@@ -20,6 +21,11 @@ COPY ./requirements.txt /simoc/requirements.txt
 RUN pip install -r /simoc/requirements.txt
 
 COPY . /simoc
+
+# Create a non-root user and set permissions
+RUN groupadd -r simoc && \
+    useradd --no-log-init -r -g simoc -s /bin/bash simoc && \
+    chown -R simoc:simoc /simoc /opt/venv
 
 ARG DB_TYPE
 ARG DB_HOST
@@ -44,6 +50,7 @@ ENV REDIS_PASSWORD ${REDIS_PASSWORD}
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+USER simoc
 WORKDIR /simoc
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This PR updates the `Dockerfile`s to create and use a `simoc` user within the container instead of running everything as `root`, as recommended in the [Docker best practices](https://docs.docker.com/build/building/best-practices/#user).

In addition it [cleans up the `apt` cache to reduce image size](https://docs.docker.com/build/building/best-practices/#apt-get).